### PR TITLE
Workflows to Publish to Chromium Webstore

### DIFF
--- a/.github/workflows/publish-chromium.yml
+++ b/.github/workflows/publish-chromium.yml
@@ -1,0 +1,26 @@
+name: Update to Chromium Webstore
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    name: Publish webextension
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - name: Build
+      run: |
+        npm ci
+        npm run build
+    - name: Upload & release
+      uses: mnao305/chrome-extension-upload@v4.0.1
+      with:
+        file-path: dist/*.zip
+        extension-id: hogefuga(extension id)
+        client-id: ${{ secrets.CLIENT_ID }}
+        client-secret: ${{ secrets.CLIENT_SECRET }}
+        refresh-token: ${{ secrets.REFRESH_TOKEN }}

--- a/.github/workflows/tester-publish-chromium.yml
+++ b/.github/workflows/tester-publish-chromium.yml
@@ -1,0 +1,28 @@
+name: Publish Chromium extension for Testers
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Publish Chromium Extension for Testers
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - name: Build
+      run: |
+        npm ci
+        npm run build
+    - name: Upload & release
+      uses: mnao305/chrome-extension-upload@v4.0.1
+      with:
+        file-path: dist/file.zip
+        extension-id: hogefuga(extension id)
+        client-id: ${{ secrets.CLIENT_ID }}
+        client-secret: ${{ secrets.CLIENT_SECRET }}
+        refresh-token: ${{ secrets.REFRESH_TOKEN }}
+        publish-target: trustedTesters


### PR DESCRIPTION
Requires `CLIENT_ID`, `CLIENT_SECRET` and `REFRESH_TOKEN` to be added to the repo environment variables.

There are 2 GH Actions in this PR.

The first one activates on the creation of a GitHub release and will publish to the webstore for everyone.
The second activates via workflow dispatch (manual activation) only and publishes to the webstore for testers.

I will be bringing support for Mozilla Firefox in a separate PR soon.
