### PR TITLE
Rename Custom Tip button

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -357,7 +357,7 @@ async function replSpotlightPathFunction(m) {
   const customTipBtnEmoji = document.createElement('span');
   const customTipBtnText = document.createElement('span');
   customTipBtnEmoji.textContent = '\u{1F300}';
-  customTipBtnText.textContent = 'Custom Tip';
+  customTipBtnText.textContent = 'Custom';
   customTipBtn.id = 'xl-replit-custom-tip-btn';
   customTipBtn.appendChild(customTipBtnEmoji);
   customTipBtn.appendChild(customTipBtnText);


### PR DESCRIPTION
Renames the Custom Tip button to Custom.

*This PR has **not** been tested. However, it should work as I've only modified a string.*